### PR TITLE
Single base url to rule them all

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -71,10 +71,6 @@ end
 # Nice URL's
 activate :directory_indexes
 
-# Be discoverable
-set :url_root, "https://www.opensourcery.co.za"
-activate :search_engine_sitemap
-
 # Disqus
 activate :disqus do |d|
   # Disqus shotname, without '.disqus.com' on the end (default = nil)
@@ -103,19 +99,6 @@ activate :syntax
 #   end
 # end
 
-helpers do
-
-  def root_url
-    config[:root_url]
-  end
-
-  def image_url(source)
-    parts = [root_url, image_path(source)].compact
-    URI.join(*parts)
-  end
-
-end
-
 # Static assets
 activate :external_pipeline,
          name: :gulp,
@@ -131,11 +114,19 @@ set :css_dir, "stylesheets"
 set :images_dir, "images"
 set :fonts_dir, "fonts"
 
+configure :development do
+  set :base_url, "http://localhost:4567"
+end
+
 # Build-specific configuration
 configure :build do
-  set :root_url, "https://www.opensourcery.co.za"
+  set :base_url, "https://www.opensourcery.co.za"
 
   activate :minify_css
   activate :minify_javascript
   activate :asset_hash
 end
+
+# Be discoverable
+set :url_root, config[:base_url] # Sitemap only
+activate :search_engine_sitemap

--- a/helpers/url_helpers.rb
+++ b/helpers/url_helpers.rb
@@ -1,0 +1,26 @@
+require 'addressable'
+
+module UrlHelpers
+  def absolute_url(path)
+    url = Addressable::URI.parse(root_url)
+    url.path = path
+    url.to_s
+  end
+
+  def encoded_url_for(path)
+    encode_component(absolute_url(path))
+  end
+
+  def encode_component(s)
+    Addressable::URI.encode_component(s, Addressable::URI::CharacterClasses::UNRESERVED)
+  end
+
+  def root_url
+    config[:base_url]
+  end
+
+  def image_url(source)
+    parts = [root_url, image_path(source)].compact
+    URI.join(*parts)
+  end
+end

--- a/source/2008-05-02-cohosting-on-rubyforge-github.html.markdown
+++ b/source/2008-05-02-cohosting-on-rubyforge-github.html.markdown
@@ -12,7 +12,7 @@ tags:
 disqus_identifier: '22 http://www.opensourcery.co.za/?p=22'
 ---
 
-Thanks to [Dr Nic Williams][1] for highlighting this at such an awesome time. I&#8217;ve got the source for ActiveRecord::Tableless now on [GitHub][2] and [RubyForge][3], thanks to git. So you can grab a copy any time you want and contribute patches <img src="http://www.opensourcery.co.za/wp-includes/images/smilies/icon_smile.gif" alt=":)" class="wp-smiley" />
+Thanks to [Dr Nic Williams][1] for highlighting this at such an awesome time. I&#8217;ve got the source for ActiveRecord::Tableless now on [GitHub][2] and [RubyForge][3], thanks to git. So you can grab a copy any time you want and contribute patches 😃
 
 Get the code via from here:
 

--- a/source/2009-03-04-ruote-in-20-minutes.html.markdown.erb
+++ b/source/2009-03-04-ruote-in-20-minutes.html.markdown.erb
@@ -21,9 +21,9 @@ Ruote (and BPM in general) isn&#8217;t a light topic, but it is a game changer i
 
 I&#8217;ll also start posting more on Ruote, as my involvement with the project grows. In the meantime, have a look at the following resources to get started:
 
-  * <a href="http://ruote.io" target="_blank">Ruote website</a>
-  * <a href="http://groups.google.com/group/openwferu-users" target="_blank">Ruote mailing list</a>
-  * \#ruote on Freenode
-  * <a href="http://jmettraux.wordpress.com/" target="_blank">John Mettraux&#8217;s blog</a>
+* <a href="http://ruote.io" target="_blank">Ruote website</a>
+* <a href="http://groups.google.com/group/openwferu-users" target="_blank">Ruote mailing list</a>
+* \#ruote on Freenode
+* <a href="http://jmettraux.wordpress.com/" target="_blank">John Mettraux&#8217;s blog</a>
 
- [1]: http://www.opensourcery.co.za/2009/08/25/ruote-in-20-minutes-video/
+[1]: <%= url_for('258') %>

--- a/source/2009-07-06-driving-business-processes-in-ruby.html.markdown.erb
+++ b/source/2009-07-06-driving-business-processes-in-ruby.html.markdown.erb
@@ -174,11 +174,11 @@ John is working hard on ruote 2.0, which is a complete rewrite of the 0.9 code b
   * [Rails Magazine 3][8]
   * [Wikipedia on Finite State Machines][5]
 
- [1]: http://www.opensourcery.co.za/2009/04/19/to-amqp-or-to-xmpp-that-is-the-question/
+ [1]: <%= url_for('173') %>
  [2]: http://jmettraux.wordpress.com/2009/07/03/state-machine-workflow-engine/
  [3]: http://ruote.io/
  [4]: http://www.ispinabox.co.za/
  [5]: http://en.wikipedia.org/wiki/Finite-state_machine
  [6]: http://github.com/pluginaweek/state_machine
- [7]: http://www.opensourcery.co.za/2009/03/04/ruote-in-20-minutes/
+ [7]: <%= url_for('159') %>
  [8]: http://railsmagazine.com/issues/3

--- a/source/2013-09-26-daemon-kit-0-3-0-rc2-is-ready.html.markdown.erb
+++ b/source/2013-09-26-daemon-kit-0-3-0-rc2-is-ready.html.markdown.erb
@@ -63,7 +63,7 @@ After that I&#8217;ll very quickly increment the minor & patch versions with imp
 Thanks for facing your daemons!
 
  [1]: https://github.com/kennethkalmer/daemon-kit/compare/v0.3.0.rc1...v0.3.0.rc2
- [2]: http://www.opensourcery.co.za/2013/09/11/daemon-kit-0-3-0-rc-is-ready/
+ [2]: <%= url_for('337') %>
  [3]: https://github.com/kennethkalmer/safely
  [4]: https://github.com/kennethkalmer/daemon-kit/issues/73
  [5]: https://github.com/kennethkalmer/daemon-kit/issues/72

--- a/source/_article.html.erb
+++ b/source/_article.html.erb
@@ -30,9 +30,8 @@
 
 		<section class="share_typesome">
 			<h4>Share: &nbsp;</h4>
-      <a class="fa fa-twitter-square" target="_blank" href="http://twitter.com/share?text=<%= article.title %>&url=http://www.opensourcery.co.za<%= article.url %>"><span class="hidden_typesome">Twitter</span></a>
-		  <a class="fa fa-facebook-square" target="_blank" href="http://www.facebook.com/sharer.php?u=http://www.opensourcery.co.za<%= article.url %>"><span class="hidden_typesome">Facebook</span></a>
-		  <a class="fa fa-google-plus-square" target="_blank" href="https://plus.google.com/share?url=http://www.opensourcery.co.za<%= article.url %>"><span class="hidden_typesome">Google+</span></a>
+      <a class="fa fa-twitter-square" target="_blank" href="https://twitter.com/share?text=<%= encode_component article.title %>&url=<%= encoded_url_for(article.url) %>"><span class="hidden_typesome">Twitter</span></a>
+		  <a class="fa fa-facebook-square" target="_blank" href="https://www.facebook.com/sharer.php?u=<%= encoded_url_for(article.url) %>"><span class="hidden_typesome">Facebook</span></a>
 		</section>
 	</footer>
 

--- a/source/clojure.xml.builder
+++ b/source/clojure.xml.builder
@@ -1,11 +1,10 @@
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-  site_url = "http://www.opensourcery.co.za/"
   xml.title "Open Sourcery"
   xml.subtitle "Performing regular wizardry through open-source software"
-  xml.id URI.join(site_url, blog.options.prefix.to_s)
-  xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
-  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
+  xml.id absolute_url(blog.options.prefix)
+  xml.link "href" => absolute_url(blog.options.prefix)
+  xml.link "href" => absolute_url(current_page.path), "rel" => "self"
   xml.author { xml.name "Kenneth Kalmer" }
 
   # Filter out only the Clojure articles
@@ -19,8 +18,8 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   clojure[0..5].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
-      xml.id URI.join(site_url, article.url)
+      xml.link "rel" => "alternate", "href" => absolute_url(article.url)
+      xml.id absolute_url(article.url)
 
       # For the older articles
       if article.data[:guid]

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,19 +1,18 @@
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
-  site_url = "http://www.opensourcery.co.za/"
   xml.title "Open Sourcery"
   xml.subtitle "Performing regular wizardry through open-source software"
-  xml.id URI.join(site_url, blog.options.prefix.to_s)
-  xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
-  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
+  xml.id absolute_url(blog.options.prefix)
+  xml.link "href" => absolute_url(blog.options.prefix)
+  xml.link "href" => absolute_url(current_page.path), "rel" => "self"
   xml.updated(blog.articles.first.date.to_time.iso8601) unless blog.articles.empty?
   xml.author { xml.name "Kenneth Kalmer" }
 
   blog.articles[0..5].each do |article|
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => URI.join(site_url, article.url)
-      xml.id URI.join(site_url, article.url)
+      xml.link "rel" => "alternate", "href" => absolute_url(article.url)
+      xml.id absolute_url(article.url)
 
       # For the older articles
       if article.data[:guid]

--- a/source/layouts/post.erb
+++ b/source/layouts/post.erb
@@ -4,7 +4,7 @@
     <meta property="og:title" content="<%= current_article.title %>">
     <meta property="og:type" content="article">
     <meta property="og:image" content="<%= image_url(image || "cover.jpg" ) %>">
-    <meta property="og:url" content="<%= root_url.to_s + current_article.url %>">
+    <meta property="og:url" content="<%= absolute_url current_article.url %>">
     <meta property="og:description" content="<%= strip_tags current_article.summary %>">
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="<%= current_article.title %>">
@@ -85,8 +85,8 @@
 
 		  <section class="sharepost_typesome">
 				<h4>Share this:</h4>
-        <a class="fa fa-twitter-square" target="_blank" href="http://twitter.com/share?text=<%= current_article.title %>&url=http://www.opensourcery.co.za<%= current_article.url %>"><span class="hidden_typesome">Twitter</span></a>
-        <a class="fa fa-facebook-square" target="_blank" href="http://www.facebook.com/sharer.php?u=http://www.opensourcery.co.za<%= current_article.url %>"><span class="hidden_typesome">Facebook</span></a>
+        <a class="fa fa-twitter-square" target="_blank" href="https://twitter.com/share?text=<%= encode_component current_article.title %>&url=<%= encoded_url_for(current_article.url) %>"><span class="hidden_typesome">Twitter</span></a>
+        <a class="fa fa-facebook-square" target="_blank" href="https://www.facebook.com/sharer.php?u=<%= encoded_url_for(current_article.url) %>"><span class="hidden_typesome">Facebook</span></a>
     	</section>
 
 		</footer>

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,1 +1,0 @@
-Sitemap: http://www.opensourcery.co.za/sitemap.xml

--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -1,0 +1,1 @@
+Sitemap: <%= url_for("/sitemap.xml") %>


### PR DESCRIPTION
One big step in prepping for a domain name change is making sure we're not hard-coding opensourcery.co.za where it doesn't need to be hardcoded.